### PR TITLE
Fix djangorestframework version for heroku deployment.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-djangorestframework
+djangorestframework==3.1.0
 django==1.7.1
 Pygments==1.5
 Markdown==2.2.0


### PR DESCRIPTION
Hi Tom,

Had to fix the version of DRF so it would be properly installed on Heroku, which runs 3.1 now.

Cheers,

Marko