### PR TITLE
Fix pagination configuration

### DIFF
--- a/tutorial/settings.py
+++ b/tutorial/settings.py
@@ -153,7 +153,7 @@ LOGGING = {
 }
 
 REST_FRAMEWORK = {
-    'PAGINATE_BY': 10,
+    'PAGE_SIZE': 10,
 }
 
 import os


### PR DESCRIPTION
Following the changes in 3.3.x PAGINATE_BY has been removed and PAGE_SIZE is now the way to go.