### PR TITLE
Restores serializers.py

### DIFF
--- a/snippets/serializers.py
+++ b/snippets/serializers.py
@@ -1,0 +1,20 @@
+from rest_framework import serializers
+from snippets.models import Snippet
+from django.contrib.auth.models import User
+
+
+class SnippetSerializer(serializers.HyperlinkedModelSerializer):
+    owner = serializers.ReadOnlyField(source='owner.username')
+    highlight = serializers.HyperlinkedIdentityField(view_name='snippet-highlight', format='html')
+
+    class Meta:
+        model = Snippet
+        fields = ('url', 'highlight', 'owner',
+                  'title', 'code', 'linenos', 'language', 'style')
+                  
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    snippets = serializers.HyperlinkedRelatedField(queryset=Snippet.objects.all(), view_name='snippet-detail', many=True)
+
+    class Meta:
+        model = User
+        fields = ('url', 'username', 'snippets')


### PR DESCRIPTION
serializers.py was removed in the last commit, this restores it to solve the import resolution error in views.py.